### PR TITLE
Fix multiple typos in Java example

### DIFF
--- a/java_example/README.md
+++ b/java_example/README.md
@@ -19,11 +19,11 @@ Run with
 
 For help, pass in the `-h` arg
 
-`./gradlew run args='-h'`
+`./gradlew run --args='-h'`
 for a description of the different arguments
 Pass in further arguments there:
 
-`.gradlew run args='--key-id=$KEY_ID --team-id=$TEAM_ID --secret-key-file-path=fake/file/path/private_key_secret.p8 --out-dir=/tmp/amf'`
+`./gradlew run --args='--key-id=$KEY_ID --team-id=$TEAM_ID --secret-key-file-path=fake/file/path/private_key_secret.p8 --out-dir=/tmp/amf'`
 
 ### Java Jar
 

--- a/java_example/app/build.gradle.kts
+++ b/java_example/app/build.gradle.kts
@@ -45,11 +45,11 @@ java {
 
 application {
     // Define the main class for the application.
-    mainClass = "com.apple.mediaFeed.example.App"
+    mainClass = "com.apple.musicFeed.example.App"
 }
 
 tasks.withType<Jar> {
     manifest {
-        attributes["Main-Class"] = "com.apple.mediaFeed.example.App"
+        attributes["Main-Class"] = "com.apple.musicFeed.example.App"
     }
 }

--- a/java_example/app/src/main/java/com/apple/musicFeed/example/App.java
+++ b/java_example/app/src/main/java/com/apple/musicFeed/example/App.java
@@ -70,7 +70,7 @@ public class App implements Callable<Integer> {
 
     @Option(names = {"--apple-music-feed-base-url"}, description = "url of Apple Music feed",
             defaultValue = "https://api.media.apple.com", required = true)
-    String appleMediaFeedBaseUrl;
+    String appleMusicFeedBaseUrl;
 
     @Option(names = {"--feed-name"}, description = "Feed name you wish to download", defaultValue = "artist",
             required = true)
@@ -89,7 +89,7 @@ public class App implements Callable<Integer> {
 
     @Override
     public Integer call() throws Exception {
-        System.out.println("Sending requests to " + appleMediaFeedBaseUrl);
+        System.out.println("Sending requests to " + appleMusicFeedBaseUrl);
         String jwt = generateJwt(secretKeyFilePath, teamId, keyId);
 
         System.out.println("Getting the latest export for feed " + feedName);
@@ -118,7 +118,7 @@ public class App implements Callable<Integer> {
     }
 
     private String getLatestExportId(String jwt) throws URISyntaxException, IOException, InterruptedException {
-        String latestUrl = appleMediaFeedBaseUrl + FEED_PREFIX + feedName + "/latest";
+        String latestUrl = appleMusicFeedBaseUrl + FEED_PREFIX + feedName + "/latest";
         HttpRequest request =
                 HttpRequest.newBuilder().GET()
                         .uri(new URI(latestUrl)).header("Authorization", "Bearer " + jwt)
@@ -142,7 +142,7 @@ public class App implements Callable<Integer> {
         int limit = 20;
 
         System.out.println("Getting the parquet file URLS from export " + latestExportId);
-        String partsUrl = appleMediaFeedBaseUrl + FEED_PREFIX + "exports/" + latestExportId + "/parts?limit=" + limit;
+        String partsUrl = appleMusicFeedBaseUrl + FEED_PREFIX + "exports/" + latestExportId + "/parts?limit=" + limit;
 
         PartResponse partResponse = (getParts(partsUrl, jwt));
         ArrayList<Part> parts = new ArrayList<>(partResponse.resources.parts.values());
@@ -150,7 +150,7 @@ public class App implements Callable<Integer> {
 
         System.out.println("Received " + parts.size() + " part urls at offset 0");
         while (!Strings.isNullOrEmpty(nextLink)) {
-            var nextUrl = appleMediaFeedBaseUrl + nextLink;
+            var nextUrl = appleMusicFeedBaseUrl + nextLink;
             var offset = getOffsetFromUrl(nextUrl)
                     .orElseThrow(() -> new PartsException("Illegally formatted nextUrl " + nextUrl));
             PartResponse nextPartResponse = getParts(nextUrl, jwt);


### PR DESCRIPTION
Hello,

I played around with this new Apple Music Feed API over the weekend, and tried to run the example scripts in this repo. The Java example has multiple typos that prevented it from building or running:

1. f6910fd50af4628115aac5e2e1bc39c4827794ed fixes the main class name in `build.gradle.kts`. With the current code, trying to run the script results in this error:

```console
$ ./gradlew run

> Task :app:run FAILED
Error: Could not find or load main class com.apple.mediaFeed.example.App
Caused by: java.lang.ClassNotFoundException: com.apple.mediaFeed.example.App

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':app:run'.
> Process 'command '/Users/mehdi/.gradle/jdks/eclipse_adoptium-17-x86_64-os_x/jdk-17.0.12+7/Contents/Home/bin/java'' finished with non-zero exit value 1

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.
> Get more help at https://help.gradle.org.

BUILD FAILED in 827ms
2 actionable tasks: 1 executed, 1 up-to-date
```

2. Followed up with de5bd931e7eafc55046f736f796eef2de170af33, which renames the occurrences of `appleMediaFeed` to `appleMusicFeed`. No errors were caused here but I think this was the intent, at least when looking at the equivalent code in the Python example.

3. Finally, 0c6f0db6b15f0475a784ace583828f897a757cd9 fixes the commands listed in the `README.md`, as trying to run `args` without the `--` gives an error:

```console
$ ./gradlew run args='-h'

FAILURE: Build failed with an exception.

* What went wrong:
Task 'args=-h' not found in root project 'apple_music_feed_example' and its subprojects.

* Try:
> Run gradlew tasks to get a list of available tasks.
> For more on name expansion, please refer to https://docs.gradle.org/8.7/userguide/command_line_interface.html#sec:name_abbreviation in the Gradle documentation.
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.
> Get more help at https://help.gradle.org.

BUILD FAILED in 578ms
```